### PR TITLE
Only run the release action on the main repo

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   build:
+    if: github.repository_owner == 'JBMod'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
It runs every time you sync a fork and that's annoying. Don't do that anymore