### PR TITLE
Few changes

### DIFF
--- a/src/game/client/c_baseviewmodel.cpp
+++ b/src/game/client/c_baseviewmodel.cpp
@@ -36,9 +36,9 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
-#ifdef CSTRIKE_DLL
+//#ifdef CSTRIKE_DLL
 	ConVar cl_righthand( "cl_righthand", "1", FCVAR_ARCHIVE, "Use right-handed view models." );
-#endif
+//#endif
 
 #ifdef TF_CLIENT_DLL
 	ConVar cl_flipviewmodels( "cl_flipviewmodels", "0", FCVAR_USERINFO | FCVAR_ARCHIVE | FCVAR_NOT_CONNECTED, "Flip view models." );
@@ -214,7 +214,7 @@ bool C_BaseViewModel::Interpolate( float currentTime )
 
 bool C_BaseViewModel::ShouldFlipViewModel()
 {
-#ifdef CSTRIKE_DLL
+//#ifdef CSTRIKE_DLL
 	// If cl_righthand is set, then we want them all right-handed.
 	CBaseCombatWeapon *pWeapon = m_hWeapon.Get();
 	if ( pWeapon )
@@ -222,7 +222,7 @@ bool C_BaseViewModel::ShouldFlipViewModel()
 		const FileWeaponInfo_t *pInfo = &pWeapon->GetWpnData();
 		return pInfo->m_bAllowFlipping && pInfo->m_bBuiltRightHanded != cl_righthand.GetBool();
 	}
-#endif
+//#endif
 
 #ifdef TF_CLIENT_DLL
 	CBaseCombatWeapon *pWeapon = m_hWeapon.Get();

--- a/src/game/server/game.cpp
+++ b/src/game/server/game.cpp
@@ -38,7 +38,7 @@ ConVar	footsteps( "mp_footsteps","1", FCVAR_NOTIFY );
 #ifdef CSTRIKE
 ConVar	flashlight( "mp_flashlight","1", FCVAR_NOTIFY );
 #else
-ConVar	flashlight( "mp_flashlight","0", FCVAR_NOTIFY );
+ConVar	flashlight( "mp_flashlight","1", FCVAR_NOTIFY );
 #endif
 ConVar	aimcrosshair( "mp_autocrosshair","1", FCVAR_NOTIFY );
 ConVar	decalfrequency( "decalfrequency","10", FCVAR_NOTIFY );

--- a/src/game/server/game.cpp
+++ b/src/game/server/game.cpp
@@ -31,7 +31,7 @@ ConVar  lservercfgfile( "lservercfgfile","listenserver.cfg" );
 
 // multiplayer server rules
 ConVar	teamplay( "mp_teamplay","0", FCVAR_NOTIFY );
-ConVar	falldamage( "mp_falldamage","0", FCVAR_NOTIFY );
+ConVar	falldamage( "mp_falldamage","0", FCVAR_NOTIFY, "If set to 0 it will return a fixed value, by the cvar mp_falldamage_amount, if set to 1 it uses realistic falldamage");
 ConVar	weaponstay( "mp_weaponstay","0", FCVAR_NOTIFY );
 ConVar	forcerespawn( "mp_forcerespawn","1", FCVAR_NOTIFY );
 ConVar	footsteps( "mp_footsteps","1", FCVAR_NOTIFY );

--- a/src/game/server/hl2/hl2_player.cpp
+++ b/src/game/server/hl2/hl2_player.cpp
@@ -81,8 +81,6 @@ extern ConVar autoaim_max_dist;
 
 extern int gEvilImpulse101;
 
-ConVar sv_autojump( "sv_autojump", "0" );
-
 ConVar hl2_walkspeed( "hl2_walkspeed", "150", FCVAR_REPLICATED );
 ConVar hl2_normspeed( "hl2_normspeed", "190", FCVAR_REPLICATED );
 ConVar hl2_sprintspeed( "hl2_sprintspeed", "320", FCVAR_REPLICATED );
@@ -651,48 +649,7 @@ void CHL2_Player::PreThink(void)
 		return;
 	}
 
-	// This is an experiment of mine- autojumping! 
-	// only affects you if sv_autojump is nonzero.
-	if( (GetFlags() & FL_ONGROUND) && sv_autojump.GetFloat() != 0 )
-	{
-		VPROF( "CHL2_Player::PreThink-Autojump" );
-		// check autojump
-		Vector vecCheckDir;
-
-		vecCheckDir = GetAbsVelocity();
-
-		float flVelocity = VectorNormalize( vecCheckDir );
-
-		if( flVelocity > 200 )
-		{
-			// Going fast enough to autojump
-			vecCheckDir = WorldSpaceCenter() + vecCheckDir * 34 - Vector( 0, 0, 16 );
-
-			trace_t tr;
-
-			UTIL_TraceHull( WorldSpaceCenter() - Vector( 0, 0, 16 ), vecCheckDir, NAI_Hull::Mins(HULL_TINY_CENTERED),NAI_Hull::Maxs(HULL_TINY_CENTERED), MASK_PLAYERSOLID, this, COLLISION_GROUP_PLAYER, &tr );
-			
-			//NDebugOverlay::Line( tr.startpos, tr.endpos, 0,255,0, true, 10 );
-
-			if( tr.fraction == 1.0 && !tr.startsolid )
-			{
-				// Now trace down!
-				UTIL_TraceLine( vecCheckDir, vecCheckDir - Vector( 0, 0, 64 ), MASK_PLAYERSOLID, this, COLLISION_GROUP_NONE, &tr );
-
-				//NDebugOverlay::Line( tr.startpos, tr.endpos, 0,255,0, true, 10 );
-
-				if( tr.fraction == 1.0 && !tr.startsolid )
-				{
-					// !!!HACKHACK
-					// I KNOW, I KNOW, this is definitely not the right way to do this,
-					// but I'm prototyping! (sjb)
-					Vector vecNewVelocity = GetAbsVelocity();
-					vecNewVelocity.z += 250;
-					SetAbsVelocity( vecNewVelocity );
-				}
-			}
-		}
-	}
+	
 
 	VPROF_SCOPE_BEGIN( "CHL2_Player::PreThink-Speed" );
 

--- a/src/game/server/jbmod/jbmod_player.cpp
+++ b/src/game/server/jbmod/jbmod_player.cpp
@@ -408,7 +408,7 @@ bool CJBMod_Player::ValidatePlayerModel( const char *pModel )
 	return false;
 }
 
-ConVar jbmod_allow_pickup( "jbmod_allow_pickup", "0", FCVAR_GAMEDLL );
+ConVar jbmod_allow_pickup( "jbmod_allow_pickup", "1", FCVAR_GAMEDLL );
 
 void CJBMod_Player::PickupObject( CBaseEntity* pObject, bool bLimitMassAndSize )
 {

--- a/src/game/server/props.cpp
+++ b/src/game/server/props.cpp
@@ -2746,6 +2746,11 @@ void CPhysicsProp::OnPhysGunPickup( CBasePlayer *pPhysGunUser, PhysGunPickup_t r
 
 	if( reason == PICKED_UP_BY_CANNON )
 	{
+		if (m_bFirstCollisionAfterLaunch)
+		{
+			PhysClearGameFlags(pPhysicsObject, FVPHYSICS_WAS_THROWN);
+			m_bFirstCollisionAfterLaunch = false;
+		}
 		m_OnPhysGunOnlyPickup.FireOutput( pPhysGunUser, this );
 	}
 

--- a/src/game/shared/gamemovement.cpp
+++ b/src/game/shared/gamemovement.cpp
@@ -58,6 +58,7 @@ ConVar player_limit_jump_speed( "player_limit_jump_speed", "1", FCVAR_REPLICATED
 // duck controls. Its value is meaningless anytime we don't have the options window open.
 ConVar option_duck_method("option_duck_method", "1", FCVAR_REPLICATED|FCVAR_ARCHIVE );// 0 = HOLD to duck, 1 = Duck is a toggle
 
+ConVar sv_autojump("sv_autojump", "0", FCVAR_REPLICATED | FCVAR_NOTIFY);
 
 // [MD] I'll remove this eventually. For now, I want the ability to A/B the optimizations.
 bool g_bMovementOptimizations = true;
@@ -2425,7 +2426,7 @@ bool CGameMovement::CheckJumpButton( void )
 		return false;
 #endif
 
-	if ( mv->m_nOldButtons & IN_JUMP )
+	if ( mv->m_nOldButtons & IN_JUMP && !sv_autojump.GetBool())
 		return false;		// don't pogo stick
 
 	// Cannot jump will in the unduck transition.

--- a/src/game/shared/jbmod/jbmod_player_shared.cpp
+++ b/src/game/shared/jbmod/jbmod_player_shared.cpp
@@ -19,6 +19,7 @@
 #include "SoundEmitterSystem/isoundemittersystembase.h"
 
 extern ConVar sv_footsteps;
+ConVar sv_material_footsteps("sv_material_footsteps", "1", FCVAR_REPLICATED, "0: HL2DM Footsteps, 1: Material Footsteps");
 
 const char *g_ppszPlayerSoundPrefixNames[PLAYER_SOUNDS_MAX] =
 {
@@ -70,6 +71,12 @@ Vector CJBMod_Player::GetAttackSpread( CBaseCombatWeapon *pWeapon, CBaseEntity *
 //-----------------------------------------------------------------------------
 void CJBMod_Player::PlayStepSound( Vector &vecOrigin, surfacedata_t *psurface, float fvol, bool force )
 {
+	if (sv_material_footsteps.GetBool())
+	{
+		BaseClass::PlayStepSound(vecOrigin, psurface, fvol, force);
+		return;
+	}
+
 	if ( gpGlobals->maxClients > 1 && !sv_footsteps.GetFloat() )
 		return;
 

--- a/src/game/shared/multiplay_gamerules.cpp
+++ b/src/game/shared/multiplay_gamerules.cpp
@@ -103,6 +103,8 @@ ConVar mp_restartgame_immediate( "mp_restartgame_immediate", "0", FCVAR_GAMEDLL,
 
 ConVar mp_mapcycle_empty_timeout_seconds( "mp_mapcycle_empty_timeout_seconds", "0", FCVAR_REPLICATED, "If nonzero, server will cycle to the next map if it has been empty on the current map for N seconds");
 
+ConVar mp_falldamage_amount("mp_falldamage_amount", "10.0", FCVAR_REPLICATED | FCVAR_NOTIFY, "If you put 10 you will loose 10, only works if mp_falldamge equals 0");
+
 void cc_SkipNextMapInCycle()
 {
 	if ( !UTIL_IsCommandIssuedByServerAdmin() )
@@ -626,6 +628,7 @@ ConVarRef suitcharger( "sk_suitcharger" );
 
 	//=========================================================
 	//=========================================================
+	//This seems to be the block of code that checks for fall damage and calculates it
 	float CMultiplayRules::FlPlayerFallDamage( CBasePlayer *pPlayer )
 	{
 		int iFallDamage = (int)falldamage.GetFloat();
@@ -637,8 +640,8 @@ ConVarRef suitcharger( "sk_suitcharger" );
 			return pPlayer->m_Local.m_flFallVelocity * DAMAGE_FOR_FALL_SPEED;
 			break;
 		default:
-		case 0:// fixed
-			return 10;
+		case 0:// fixed by the cvar mp_falldamage_amount
+			return mp_falldamage_amount.GetFloat();
 			break;
 		}
 	} 


### PR DESCRIPTION
Small but needed update

- Restored cl_righthand cvar
- Changed the value of two commands, mp_flashlight and jbmod_allow_pickup now they are by default true
- Autojump added, now you can bhop
- Falldamage customizable, if mp_falldamage is 0 and mp_falldamage_amount is changed to any value the player wants, everytime they recieve fall damage they will recieve that value, for example you could put mp_falldamage_amount to 0 and players wont recieve fall damage
- A minor issue with the gravity gun has been fixed, if you grabbed something like an explosive barrel, threw it upwards, and then caught it in mid air, it would explode if it touched the ground, even slightly. It makes more sense now
- Restored per material footsteps, its customizable, if the convar sv_material_footsteps is true, the footstep sounds will be like in the singleplayer branch, per material, if sv_material_footsteps is false, then it would sound just like hl2dm sounds.

Thats all the changes